### PR TITLE
gocmd ls: add human-readable size parameter

### DIFF
--- a/cmd/flag/list.go
+++ b/cmd/flag/list.go
@@ -16,6 +16,7 @@ type ListFlagValues struct {
 	Format              ListFormat
 	longFormatInput     bool
 	veryLongFormatInput bool
+	HumanReadableSizes  bool
 }
 
 var (
@@ -25,6 +26,7 @@ var (
 func SetListFlags(command *cobra.Command) {
 	command.Flags().BoolVarP(&listFlagValues.longFormatInput, "long", "l", false, "Display in a long format")
 	command.Flags().BoolVarP(&listFlagValues.veryLongFormatInput, "verylong", "L", false, "Display in a very long format")
+	command.Flags().BoolVarP(&listFlagValues.HumanReadableSizes, "human-readable", "H", false, "Display sizes in human-readable format")
 }
 
 func GetListFlagValues() *ListFlagValues {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/creativeprojects/go-selfupdate v1.0.1
 	github.com/cyverse/go-irodsclient v0.12.9
 	github.com/gliderlabs/ssh v0.3.5
+	github.com/dustin/go-humanize v1.0.1
 	github.com/jedib0t/go-pretty/v6 v6.3.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/rs/xid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/cyverse/go-irodsclient v0.12.9/go.mod h1:9douI0OllPASzv9wwlOwbpnfI8xw
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
With this parameter, "gocmd ls" displays sizes as e.g. "10 MB" instead of "10247680".