### PR TITLE
Fix segfault when putting without supplying --encrypt/no_encrypt option

### DIFF
--- a/cmd/subcmd/put.go
+++ b/cmd/subcmd/put.go
@@ -288,7 +288,7 @@ func (put *PutCommand) requireEncryption(targetPath string, parentEncryption boo
 		targetEntry, err := put.filesystem.Stat(targetPath)
 		if err != nil {
 			if irodsclient_types.IsFileNotFoundError(err) {
-				targetDir = commons.GetDir(targetEntry.Path)
+				targetDir = commons.GetDir(targetPath)
 			} else {
 				return parentEncryption, parentEncryptionMode
 			}


### PR DESCRIPTION
When running put, I get
```
$ gocmd put -k [source] [destination]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x9be49a]

goroutine 1 [running]:
github.com/cyverse/gocommands/cmd/subcmd.(*PutCommand).requireEncryption(0xc0001d4340, {0x7ffecd34d65e, 0x34}, 0x14?, {0x0, 0x0})
        /github/workspace/cmd/subcmd/put.go:291 +0xfa
...
```
The cause of this is that when `filesystem.Stat` returns an error, the returned `targetEntry` is `nil`.  `GetDir` should be passed the original `targetPath`, rather than trying to get the path from `targetEntry` here.