### PR TITLE
Add wildcard support for collections and objects

### DIFF
--- a/cmd/flag/bundle.go
+++ b/cmd/flag/bundle.go
@@ -3,9 +3,10 @@ package flag
 import "github.com/spf13/cobra"
 
 type BundleFlagValues struct {
-	Extract          bool
-	BulkRegistration bool
-	DataType         string
+	Extract           bool
+	BulkRegistration  bool
+	WildcardExpansion bool
+	DataType          string
 }
 
 var (
@@ -15,6 +16,7 @@ var (
 func SetBundleFlags(command *cobra.Command) {
 	command.Flags().BoolVarP(&bundleFlagValues.Extract, "extract", "x", false, "Extract")
 	command.Flags().BoolVarP(&bundleFlagValues.BulkRegistration, "bulk", "b", false, "Enable bulk registration")
+	command.Flags().BoolVarP(&bundleFlagValues.WildcardExpansion, "wildcard", "w", false, "Enable wildcard expansion")
 	command.Flags().StringVarP(&bundleFlagValues.DataType, "data_type", "D", "", "Set data type (tar, zip ...)")
 }
 

--- a/cmd/flag/list.go
+++ b/cmd/flag/list.go
@@ -10,6 +10,7 @@ type ListFlagValues struct {
 	longFormatInput     bool
 	veryLongFormatInput bool
 	HumanReadableSizes  bool
+	WildcardExpansion   bool
 
 	SortOrder      commons.ListSortOrder
 	sortOrderInput string
@@ -26,6 +27,7 @@ func SetListFlags(command *cobra.Command) {
 	command.Flags().BoolVarP(&listFlagValues.HumanReadableSizes, "human_readable", "H", false, "Display sizes in human-readable format")
 	command.Flags().BoolVar(&listFlagValues.SortReverse, "reverse_sort", false, "Sort in reverse order")
 	command.Flags().StringVarP(&listFlagValues.sortOrderInput, "sort", "S", "name", "Sort on name, size, time or ext")
+	command.Flags().BoolVarP(&listFlagValues.WildcardExpansion, "wildcard", "w", false, "Enable wildcard expansion")
 }
 
 func GetListFlagValues() *ListFlagValues {

--- a/cmd/flag/wildcard.go
+++ b/cmd/flag/wildcard.go
@@ -1,0 +1,21 @@
+package flag
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type WildcardSearchFlagValues struct {
+	WildcardSearch bool
+}
+
+var (
+	wildcardSearchFlagValues WildcardSearchFlagValues
+)
+
+func SetWildcardSearchFlags(command *cobra.Command) {
+	command.Flags().BoolVarP(&wildcardSearchFlagValues.WildcardSearch, "wildcard", "w", false, "Enable wildcard expansion")
+}
+
+func GetWildcardSearchFlagValues() *WildcardSearchFlagValues {
+	return &wildcardSearchFlagValues
+}

--- a/cmd/subcmd/bun.go
+++ b/cmd/subcmd/bun.go
@@ -98,6 +98,14 @@ func (bun *BunCommand) Process() error {
 	}
 	defer bun.filesystem.Release()
 
+	// Expand wildcards
+	if bun.bundleFlagValues.WildcardExpansion {
+		bun.sourcePaths, err = commons.ExpandWildcards(bun.filesystem, bun.account, bun.sourcePaths, false, true)
+		if err != nil {
+			return xerrors.Errorf("failed to expand wildcards:  %w", err)
+		}
+	}
+
 	// run
 	for _, sourcePath := range bun.sourcePaths {
 		if bun.bundleFlagValues.Extract {

--- a/cmd/subcmd/get.go
+++ b/cmd/subcmd/get.go
@@ -49,6 +49,7 @@ func AddGetCommand(rootCmd *cobra.Command) {
 	flag.SetPostTransferFlagValues(getCmd)
 	flag.SetHiddenFileFlags(getCmd)
 	flag.SetTransferReportFlags(getCmd)
+	flag.SetWildcardSearchFlags(getCmd)
 
 	rootCmd.AddCommand(getCmd)
 }
@@ -81,6 +82,7 @@ type GetCommand struct {
 	postTransferFlagValues         *flag.PostTransferFlagValues
 	hiddenFileFlagValues           *flag.HiddenFileFlagValues
 	transferReportFlagValues       *flag.TransferReportFlagValues
+	wildcardSearchFlagValues       *flag.WildcardSearchFlagValues
 
 	maxConnectionNum int
 
@@ -115,6 +117,7 @@ func NewGetCommand(command *cobra.Command, args []string) (*GetCommand, error) {
 		postTransferFlagValues:         flag.GetPostTransferFlagValues(),
 		hiddenFileFlagValues:           flag.GetHiddenFileFlagValues(),
 		transferReportFlagValues:       flag.GetTransferReportFlagValues(command),
+		wildcardSearchFlagValues:       flag.GetWildcardSearchFlagValues(),
 
 		updatedPathMap: map[string]bool{},
 	}
@@ -204,6 +207,14 @@ func (get *GetCommand) Process() error {
 		err = get.ensureTargetIsDir(get.targetPath)
 		if err != nil {
 			return err
+		}
+	}
+
+	// Expand wildcards
+	if get.wildcardSearchFlagValues.WildcardSearch {
+		get.sourcePaths, err = commons.ExpandWildcards(get.filesystem, get.account, get.sourcePaths, true, true)
+		if err != nil {
+			return xerrors.Errorf("failed to expand wildcards:  %w", err)
 		}
 	}
 

--- a/cmd/subcmd/ls.go
+++ b/cmd/subcmd/ls.go
@@ -131,6 +131,15 @@ func (ls *LsCommand) Process() error {
 		ls.decryptionFlagValues.Key = ls.account.Password
 	}
 
+	// Expand wildcards
+	if ls.listFlagValues.WildcardExpansion {
+		expanded_results, err := commons.ExpandWildcards(ls.filesystem, ls.account, ls.sourcePaths, true, true)
+		if err != nil {
+			return xerrors.Errorf("failed to expand wildcards:  %w", err)
+		}
+		ls.sourcePaths = expanded_results
+	}
+
 	// run
 	for _, sourcePath := range ls.sourcePaths {
 		err = ls.listOne(sourcePath)

--- a/commons/path.go
+++ b/commons/path.go
@@ -41,6 +41,30 @@ func MakeIRODSPath(cwd string, homedir string, zone string, irodsPath string) st
 	return path.Clean(newPath)
 }
 
+func getIRODSPathDirname(path string) string {
+	p := strings.TrimRight(path, "/")
+	idx := strings.LastIndex(p, "/")
+
+	if idx < 0 {
+		return p
+	} else if idx == 0 {
+		return "/"
+	} else {
+		return p[:idx]
+	}
+}
+
+func getIRODSPathBasename(path string) string {
+	p := strings.TrimRight(path, "/")
+	idx := strings.LastIndex(p, "/")
+
+	if idx < 0 {
+		return p
+	} else {
+		return p[idx+1:]
+	}
+}
+
 func MakeLocalPath(localPath string) string {
 	absLocalPath, err := filepath.Abs(localPath)
 	if err != nil {

--- a/commons/wildcard_expansion.go
+++ b/commons/wildcard_expansion.go
@@ -1,0 +1,212 @@
+package commons
+
+import (
+	"fmt"
+	irodsclient_fs "github.com/cyverse/go-irodsclient/fs"
+	"github.com/cyverse/go-irodsclient/irods/common"
+	"github.com/cyverse/go-irodsclient/irods/connection"
+	"github.com/cyverse/go-irodsclient/irods/message"
+	"github.com/cyverse/go-irodsclient/irods/types"
+	"github.com/danwakefield/fnmatch"
+	"github.com/dlclark/regexp2"
+	"golang.org/x/xerrors"
+	"regexp"
+	"strings"
+)
+
+func ExpandWildcards(fs *irodsclient_fs.FileSystem, account *types.IRODSAccount, input []string, expand_collections bool, expand_dataobjects bool) ([]string, error) {
+
+	if !expand_collections && !expand_dataobjects {
+		return nil, xerrors.Errorf("Need to enable data objects or collections (or both) for wildcard expansion.")
+	}
+	output := make([]string, 0)
+
+	conn, err_connection := fs.GetMetadataConnection()
+	if err_connection != nil {
+		return nil, xerrors.Errorf("failed to get connection: %w", err_connection)
+	}
+	defer fs.ReturnMetadataConnection(conn)
+
+	for i := 0; i < len(input); i++ {
+		if hasWildcards(input[i]) {
+			// First convert input to absolute path
+			cwd := GetCWD()
+			home := GetHomeDir()
+			zone := account.ClientZone
+			absolute_path := MakeIRODSPath(cwd, home, zone, input[i])
+
+			// Convert Unix wildcards into strings for SQL queries
+			absolute_path_sql_wildcard := unixWildcardsToSQLWildcards(absolute_path)
+			basename_sql_wildcard := getIRODSPathBasename(absolute_path_sql_wildcard)
+			dirname_sql_wildcard := getIRODSPathDirname(absolute_path_sql_wildcard)
+
+			// Perform queries
+			query_results := make([]string, 0)
+			if expand_collections {
+				coll_query_results, err := wildcardSearchCollection(conn, absolute_path_sql_wildcard)
+				if err != nil {
+					return nil, xerrors.Errorf("failed to perform collection query for wildcard expansion: %w", err)
+				}
+				query_results = append(query_results, (*coll_query_results)...)
+			}
+			if expand_dataobjects {
+				do_query_results, err := wildcardSearchDataObject(conn, dirname_sql_wildcard, basename_sql_wildcard)
+				if err != nil {
+					return nil, xerrors.Errorf("failed to perform data object query for wildcard expansion: %w", err)
+				}
+				query_results = append(query_results, (*do_query_results)...)
+			}
+
+			// Add results to output. Filter results by original unix wildcard, since the SQL wildcards
+			// are less strict (e.g. a unix wildcard range is converted to a generic
+			// wildcards in SQL).
+
+			for j := 0; j < len(query_results); j++ {
+				if fnmatch.Match(absolute_path, query_results[j], fnmatch.FNM_PATHNAME) {
+					output = append(output, query_results[j])
+				}
+			}
+
+		} else {
+			output = append(output, input[i])
+		}
+	}
+	return output, nil
+}
+
+func hasWildcards(input string) bool {
+	return (regexp.MustCompile(`(?:[^\\])(?:\\\\)*[?*]`).MatchString(input) ||
+		regexp.MustCompile(`^(?:\\\\)*[?*]`).MatchString(input) ||
+		regexp.MustCompile(`(?:[^\\])(?:\\\\)*\[.*?(?:[^\\])(?:\\\\)*\]`).MatchString(input) ||
+		regexp.MustCompile(`^(?:\\\\)*\[.*?(?:[^\\])(?:\\\\)*\]`).MatchString(input))
+}
+
+func unixWildcardsToSQLWildcards(input string) string {
+	output := input
+	length := len(input)
+	// Use regexp2 rather than regexp here in order to be able to use lookbehind assertions
+	//
+	// Escape SQL wildcard characters
+	output = strings.ReplaceAll(output, "%", `\%`)
+	output = strings.ReplaceAll(output, "_", `\_`)
+	// Replace ranges with a wildcard
+	output, _ = regexp2.MustCompile(`(?<!\\)(?:\\\\)*\[.*?(?<!\\)(?:\\\\)*\]`, regexp2.RE2).Replace(output, `_`, 0, length)
+	// Replace non-escaped regular wildcard characters with SQL equivalents
+	output, _ = regexp2.MustCompile(`(?<!\\)(?:\\\\)*(\*)`, regexp2.RE2).Replace(output, `%`, 0, length)
+	output, _ = regexp2.MustCompile(`(?<!\\)(?:\\\\)*(\?)`, regexp2.RE2).Replace(output, `_`, 0, length)
+	return output
+}
+
+func wildcardSearchCollection(conn *connection.IRODSConnection, collection_wildcard_value string) (*[]string, error) {
+	if conn == nil || !conn.IsConnected() {
+		return nil, xerrors.Errorf("connection is nil or disconnected")
+	}
+
+	// lock the connection
+	conn.Lock()
+	defer conn.Unlock()
+
+	continueQuery := true
+	continueIndex := 0
+	results := make([]string, 0)
+
+	for continueQuery {
+		query := message.NewIRODSMessageQueryRequest(common.MaxQueryRows, continueIndex, 0, 0)
+		query.AddKeyVal(common.ZONE_KW, conn.GetAccount().ClientZone)
+		query.AddSelect(common.ICAT_COLUMN_COLL_NAME, 1)
+
+		wildcard_condition := fmt.Sprintf("LIKE '%s'", collection_wildcard_value)
+		query.AddCondition(common.ICAT_COLUMN_COLL_NAME, wildcard_condition)
+
+		queryResult := message.IRODSMessageQueryResponse{}
+		err := conn.Request(query, &queryResult, nil)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to receive a collection query result message: %w", err)
+		}
+
+		err = queryResult.CheckError()
+		if err != nil {
+			if types.GetIRODSErrorCode(err) == common.CAT_NO_ROWS_FOUND {
+				// empty
+				break
+			}
+			return nil, xerrors.Errorf("received collection query error: %w", err)
+		}
+
+		if queryResult.RowCount == 0 {
+			break
+		}
+
+		sqlResult := queryResult.SQLResult[0]
+		for row := 0; row < queryResult.RowCount; row++ {
+			results = append(results, sqlResult.Values[row])
+		}
+
+		continueIndex = queryResult.ContinueIndex
+		if continueIndex == 0 {
+			continueQuery = false
+		}
+	}
+
+	return &results, nil
+
+}
+
+func wildcardSearchDataObject(conn *connection.IRODSConnection, collection_wildcard_value string, dataobject_wildcard_value string) (*[]string, error) {
+	if conn == nil || !conn.IsConnected() {
+		return nil, xerrors.Errorf("connection is nil or disconnected")
+	}
+
+	// lock the connection
+	conn.Lock()
+	defer conn.Unlock()
+
+	continueQuery := true
+	continueIndex := 0
+	results := make([]string, 0)
+
+	for continueQuery {
+		query := message.NewIRODSMessageQueryRequest(common.MaxQueryRows, continueIndex, 0, 0)
+		query.AddKeyVal(common.ZONE_KW, conn.GetAccount().ClientZone)
+		query.AddSelect(common.ICAT_COLUMN_COLL_NAME, 1)
+		query.AddSelect(common.ICAT_COLUMN_DATA_NAME, 1)
+
+		collection_wildcard_condition := fmt.Sprintf("LIKE '%s'", collection_wildcard_value)
+		query.AddCondition(common.ICAT_COLUMN_COLL_NAME, collection_wildcard_condition)
+
+		dataobject_wildcard_condition := fmt.Sprintf("LIKE '%s'", dataobject_wildcard_value)
+		query.AddCondition(common.ICAT_COLUMN_DATA_NAME, dataobject_wildcard_condition)
+
+		queryResult := message.IRODSMessageQueryResponse{}
+		err := conn.Request(query, &queryResult, nil)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to receive a collection query result message: %w", err)
+		}
+
+		err = queryResult.CheckError()
+		if err != nil {
+			if types.GetIRODSErrorCode(err) == common.CAT_NO_ROWS_FOUND {
+				// empty
+				break
+			}
+			return nil, xerrors.Errorf("received collection query error: %w", err)
+		}
+
+		if queryResult.RowCount == 0 {
+			break
+		}
+
+		collectionResult := queryResult.SQLResult[0]
+		dataObjectResult := queryResult.SQLResult[1]
+		for row := 0; row < queryResult.RowCount; row++ {
+			results = append(results, collectionResult.Values[row]+"/"+dataObjectResult.Values[row])
+		}
+
+		continueIndex = queryResult.ContinueIndex
+		if continueIndex == 0 {
+			continueQuery = false
+		}
+	}
+
+	return &results, nil
+}

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -20,6 +20,12 @@ For example, to download a whole directory `/iplant/home/iychoi/test_data` in iR
 gocmd get /iplant/home/iychoi/test_data .
 ```
 
+In order to use wildcards, add the `-w` option. For example, in order to download all CSV files from the `test_data` collection:
+
+```bash
+gocmd get -w '/iplant/home/iychoi/test_data/*.csv' .
+```
+
 Of course, you can use relative path from your iRODS current working directory to locate input. Use `pwd` and `cd` subcommand to display and change iRODS current working directory.
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/creativeprojects/go-selfupdate v1.0.1
 	github.com/cyverse/go-irodsclient v0.15.8
+	github.com/dlclark/regexp2 v1.11.4
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gliderlabs/ssh v0.3.5
 	github.com/jedib0t/go-pretty/v6 v6.3.1
@@ -22,6 +23,7 @@ require (
 	code.gitea.io/sdk/gitea v0.15.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
+	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,9 +11,13 @@ github.com/creativeprojects/go-selfupdate v1.0.1 h1:5Un4MTv4puCR5GBgkDLC14J72flj
 github.com/creativeprojects/go-selfupdate v1.0.1/go.mod h1:nm7AWUJfrfYt/SB97NAcMhR0KEpPqlrVHXkWFti+ezw=
 github.com/cyverse/go-irodsclient v0.15.8 h1:ZiO5DDiyTL7+vfhqtNWtZWcHlWO+p6iieWTcLa8zcZA=
 github.com/cyverse/go-irodsclient v0.15.8/go.mod h1:NN+PxHfLDUmsqfqSY84JfmqXS4EYiuiNW6ti6oPGCgk=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=


### PR DESCRIPTION
This makes it possible to use wildcards to match collections and data objects in the iRODS zone.

For example:

To download all CSV files from the current directory:

```bash
$ gocmd get -w '*.csv'
```

To remove directories `dir2`, `dir3` and `dir4`:

```bash
$ gocmd rmdir -w 'dir[234]'
```

To list all one-character name ZIP files (e.g. `a.zip`, `b.zip`, etc.):

```bash
$ gocmd ls -w '?.zip'
```