### PR TITLE
honor the value of IRODS_ENVIRONMENT_FILE

### DIFF
--- a/cmd/flag/common.go
+++ b/cmd/flag/common.go
@@ -28,10 +28,6 @@ type CommonFlagValues struct {
 	ResourceUpdated bool
 }
 
-const (
-	IRODSEnvironmentFileEnvKey string = "IRODS_ENVIRONMENT_FILE"
-)
-
 var (
 	commonFlagValues CommonFlagValues
 )
@@ -195,13 +191,6 @@ func ProcessCommonFlags(command *cobra.Command) (bool, error) {
 	environmentManager.SetPPID(myCommonFlagValues.SessionID)
 
 	configFilePath := ""
-
-	// find config file location from env
-	if irodsEnvironmentFileEnvVal, ok := os.LookupEnv(IRODSEnvironmentFileEnvKey); ok {
-		if len(irodsEnvironmentFileEnvVal) > 0 {
-			configFilePath = irodsEnvironmentFileEnvVal
-		}
-	}
 
 	// user defined config file
 	if len(myCommonFlagValues.ConfigFilePath) > 0 {

--- a/commons/config.go
+++ b/commons/config.go
@@ -1,18 +1,31 @@
 package commons
 
 import (
+	"os"
+
 	"golang.org/x/xerrors"
 
 	"gopkg.in/yaml.v3"
 )
 
-// GetDefaultIRODSConfigPath returns default config path
+const (
+	IRODSEnvironmentFileEnvKey string = "IRODS_ENVIRONMENT_FILE"
+)
+
+// GetDefaultIRODSConfigPath returns default config path for the process environment
 func GetDefaultIRODSConfigPath() string {
+	// use the path specified in the environment if present
+	if irodsEnvironmentFileEnvVal, ok := os.LookupEnv(IRODSEnvironmentFileEnvKey); ok {
+		if len(irodsEnvironmentFileEnvVal) > 0 {
+			return irodsEnvironmentFileEnvVal
+		}
+	}
+
+	// fall back to the default path
 	irodsConfigPath, err := ExpandHomeDir("~/.irods")
 	if err != nil {
 		return ""
 	}
-
 	return irodsConfigPath
 }
 


### PR DESCRIPTION
This is a small change to ensure that the value of the `IRODS_ENVIRONMENT_FILE` environment variable is honored when it's specified. With this change, the `--config` command-line option always takes precedence. If the command-line option is not specified then the `IRODS_ENVIRONMENT_FILE` is checked next. If that's not specified, then the default configuration file path is used: `$HOME/.irods/irods`

Here are some examples:

```
$ bin/gocmd env
+------------------------------+---------------------------------------------------+
| Session Environment File     | /Users/sarahr/.irods/irods_environment.json.85135 |
| Environment File             | /Users/sarahr/.irods/irods_environment.json       |
| Authentication File          | /Users/sarahr/.irods/.irodsA                      |
| Host                         | data.cyverse.org                                  |
| Port                         | 1247                                              |
| Zone                         | iplant                                            |
| Username                     | de-irods                                          |
| Client Zone                  | iplant                                            |
| Client Username              | de-irods                                          |
| Default Resource             |                                                   |
| Current Working Dir          | /iplant/home/de-irods                             |
| Home                         | /iplant/home/de-irods                             |
| Default Hash Scheme          | SHA256                                            |
| Log Level                    | 0                                                 |
| Authentication Scheme        | native                                            |
| Client Server Negotiation    | off                                               |
| Client Server Policy         | CS_NEG_REFUSE                                     |
| SSL CA Certification File    |                                                   |
| SSL CA Certification Path    |                                                   |
| SSL Verify Server            | hostname                                          |
| SSL Encryption Key Size      | 32                                                |
| SSL Encryption Key Algorithm | AES-256-CBC                                       |
| SSL Encryption Salt Size     | 8                                                 |
| SSL Encryption Hash Rounds   | 16                                                |
+------------------------------+---------------------------------------------------+

$ bin/gocmd env --config "$HOME/.gocmd"
+------------------------------+---------------------------------------------------+
| Session Environment File     | /Users/sarahr/.gocmd/irods_environment.json.85135 |
| Environment File             | /Users/sarahr/.gocmd/irods_environment.json       |
| Authentication File          | /Users/sarahr/.irods/.irodsA                      |
| Host                         | data.cyverse.org                                  |
| Port                         | 1247                                              |
| Zone                         | iplant                                            |
| Username                     | de-irods                                          |
| Client Zone                  | iplant                                            |
| Client Username              | de-irods                                          |
| Default Resource             |                                                   |
| Current Working Dir          | /iplant/home/de-irods                             |
| Home                         | /iplant/home/de-irods                             |
| Default Hash Scheme          | SHA256                                            |
| Log Level                    | 0                                                 |
| Authentication Scheme        | native                                            |
| Client Server Negotiation    | off                                               |
| Client Server Policy         | CS_NEG_REFUSE                                     |
| SSL CA Certification File    |                                                   |
| SSL CA Certification Path    |                                                   |
| SSL Verify Server            | hostname                                          |
| SSL Encryption Key Size      | 32                                                |
| SSL Encryption Key Algorithm | AES-256-CBC                                       |
| SSL Encryption Salt Size     | 8                                                 |
| SSL Encryption Hash Rounds   | 16                                                |
+------------------------------+---------------------------------------------------+

$ bin/gocmd env --config "$HOME/.irods/irods_environment_foo.json"
+------------------------------+-------------------------------------------------------+
| Session Environment File     | /Users/sarahr/.irods/irods_environment_foo.json.85135 |
| Environment File             | /Users/sarahr/.irods/irods_environment_foo.json       |
| Authentication File          | /Users/sarahr/.irods/.irodsA                          |
| Host                         | data.cyverse.org                                      |
| Port                         | 1247                                                  |
| Zone                         | iplant                                                |
| Username                     | de-irods                                              |
| Client Zone                  | iplant                                                |
| Client Username              | de-irods                                              |
| Default Resource             |                                                       |
| Current Working Dir          | /iplant/home/de-irods                                 |
| Home                         | /iplant/home/de-irods                                 |
| Default Hash Scheme          | SHA256                                                |
| Log Level                    | 0                                                     |
| Authentication Scheme        | native                                                |
| Client Server Negotiation    | off                                                   |
| Client Server Policy         | CS_NEG_REFUSE                                         |
| SSL CA Certification File    |                                                       |
| SSL CA Certification Path    |                                                       |
| SSL Verify Server            | hostname                                              |
| SSL Encryption Key Size      | 32                                                    |
| SSL Encryption Key Algorithm | AES-256-CBC                                           |
| SSL Encryption Salt Size     | 8                                                     |
| SSL Encryption Hash Rounds   | 16                                                    |
+------------------------------+-------------------------------------------------------+

$ IRODS_ENVIRONMENT_FILE="$HOME/.gocmd" bin/gocmd env
+------------------------------+---------------------------------------------------+
| Session Environment File     | /Users/sarahr/.gocmd/irods_environment.json.85135 |
| Environment File             | /Users/sarahr/.gocmd/irods_environment.json       |
| Authentication File          | /Users/sarahr/.irods/.irodsA                      |
| Host                         | data.cyverse.org                                  |
| Port                         | 1247                                              |
| Zone                         | iplant                                            |
| Username                     | de-irods                                          |
| Client Zone                  | iplant                                            |
| Client Username              | de-irods                                          |
| Default Resource             |                                                   |
| Current Working Dir          | /iplant/home/de-irods                             |
| Home                         | /iplant/home/de-irods                             |
| Default Hash Scheme          | SHA256                                            |
| Log Level                    | 0                                                 |
| Authentication Scheme        | native                                            |
| Client Server Negotiation    | off                                               |
| Client Server Policy         | CS_NEG_REFUSE                                     |
| SSL CA Certification File    |                                                   |
| SSL CA Certification Path    |                                                   |
| SSL Verify Server            | hostname                                          |
| SSL Encryption Key Size      | 32                                                |
| SSL Encryption Key Algorithm | AES-256-CBC                                       |
| SSL Encryption Salt Size     | 8                                                 |
| SSL Encryption Hash Rounds   | 16                                                |
+------------------------------+---------------------------------------------------+

$ IRODS_ENVIRONMENT_FILE="$HOME/.irods/irods_environment_foo.json" bin/gocmd env
+------------------------------+-------------------------------------------------------+
| Session Environment File     | /Users/sarahr/.irods/irods_environment_foo.json.85135 |
| Environment File             | /Users/sarahr/.irods/irods_environment_foo.json       |
| Authentication File          | /Users/sarahr/.irods/.irodsA                          |
| Host                         | data.cyverse.org                                      |
| Port                         | 1247                                                  |
| Zone                         | iplant                                                |
| Username                     | de-irods                                              |
| Client Zone                  | iplant                                                |
| Client Username              | de-irods                                              |
| Default Resource             |                                                       |
| Current Working Dir          | /iplant/home/de-irods                                 |
| Home                         | /iplant/home/de-irods                                 |
| Default Hash Scheme          | SHA256                                                |
| Log Level                    | 0                                                     |
| Authentication Scheme        | native                                                |
| Client Server Negotiation    | off                                                   |
| Client Server Policy         | CS_NEG_REFUSE                                         |
| SSL CA Certification File    |                                                       |
| SSL CA Certification Path    |                                                       |
| SSL Verify Server            | hostname                                              |
| SSL Encryption Key Size      | 32                                                    |
| SSL Encryption Key Algorithm | AES-256-CBC                                           |
| SSL Encryption Salt Size     | 8                                                     |
| SSL Encryption Hash Rounds   | 16                                                    |
+------------------------------+-------------------------------------------------------+

$ IRODS_ENVIRONMENT_FILE="$HOME/.irods/irods_environment.json" bin/gocmd env --config "$HOME/.irods/irods_environment_foo.json"
+------------------------------+-------------------------------------------------------+
| Session Environment File     | /Users/sarahr/.irods/irods_environment_foo.json.85135 |
| Environment File             | /Users/sarahr/.irods/irods_environment_foo.json       |
| Authentication File          | /Users/sarahr/.irods/.irodsA                          |
| Host                         | data.cyverse.org                                      |
| Port                         | 1247                                                  |
| Zone                         | iplant                                                |
| Username                     | de-irods                                              |
| Client Zone                  | iplant                                                |
| Client Username              | de-irods                                              |
| Default Resource             |                                                       |
| Current Working Dir          | /iplant/home/de-irods                                 |
| Home                         | /iplant/home/de-irods                                 |
| Default Hash Scheme          | SHA256                                                |
| Log Level                    | 0                                                     |
| Authentication Scheme        | native                                                |
| Client Server Negotiation    | off                                                   |
| Client Server Policy         | CS_NEG_REFUSE                                         |
| SSL CA Certification File    |                                                       |
| SSL CA Certification Path    |                                                       |
| SSL Verify Server            | hostname                                              |
| SSL Encryption Key Size      | 32                                                    |
| SSL Encryption Key Algorithm | AES-256-CBC                                           |
| SSL Encryption Salt Size     | 8                                                     |
| SSL Encryption Hash Rounds   | 16                                                    |
+------------------------------+-------------------------------------------------------+
```

I haven't decided whether or not this is a drawback, but one feature of this implementation is that setting the `IRODS_ENVIRONMENT_FILE` environment variable also changes the `gocmd` help message:

```
$ gocmd help | grep -- --config
  -c, --config string      Specify custom iRODS configuration file or directory path (default "/Users/sarahr/.irods")

$ IRODS_ENVIRONMENT_FILE="$HOME/.gocmd" bin/gocmd help | grep -- --config
  -c, --config string      Specify custom iRODS configuration file or directory path (default "/Users/sarahr/.gocmd")
```
