### PR TITLE
cp command: minor fix for --delete

### DIFF
--- a/cmd/subcmd/cp.go
+++ b/cmd/subcmd/cp.go
@@ -1000,7 +1000,7 @@ func (cp *CpCommand) deleteExtraDir(targetEntry *irodsclient_fs.Entry) error {
 			}
 		} else {
 			// file
-			err = cp.deleteExtraDir(entry)
+			err = cp.deleteExtraFile(entry)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This fixes a minor issue where `gocmd cp --delete -r col1 col2` could fail to delete a data object in col2 with a
`CAT_NAME_EXISTS_AS_DATAOBJ` error, because it tries to delete it as a collection rather than as a data object.